### PR TITLE
Update install

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -11,7 +11,9 @@ in order to install and play around with the Perl101.org codebase.
   using the following command:
   $ jemplate --compile tt/show_captcha.tt tt/show_result.tt > static/js/jmpls.js
   (you must have Jemplate installed)
-- Run the crank script.
+- Clone the `podium` repo from https://github.com/petdance/podium. Install it
+  using `cpanm .`.
+- Run the Makefile: `make`.
 - Copy the built HTML files in your "build" folder into the document root of
   your Perl101.
 - Copy the "static" folder to the same document root.

--- a/INSTALL
+++ b/INSTALL
@@ -4,7 +4,7 @@ in order to install and play around with the Perl101.org codebase.
 - Install a webserver (apache, lighttpd, etc.).
 - Create the "build" folder for the "crank" script.
 - Make sure that the "href" path defined in "section.tt"'s javascript matches
-  where your CGI folder will be. It assumes it well be in "/cgi-bin".
+  where your CGI folder will be. It assumes it will be in "/cgi-bin".
 - Make sure that the path for the captcha pictures hardcoded in
   "tt/show_captcha.tt" is good for you.
 - If you need to adjust the path in "show_captcha.tt", recompile the templates


### PR DESCRIPTION
GH #9 refers to installation instructions which don't help. This is because a change was introduced in the Makefile. I updated the INSTALL reference document to reflect that.

(I had done this on a new fork to avoid rebase/merge issues from the _really_ old one)

:)
